### PR TITLE
Arbiter: Handle GPS week rollover

### DIFF
--- a/ntpd/refclock_arbiter.c
+++ b/ntpd/refclock_arbiter.c
@@ -355,6 +355,9 @@ arb_receive(
 		return;
 	}
 
+	if (pp->year < 20)		/* GPS week rollover? */
+	    pp->day += (1024*7);
+
 	/*
 	 * We decode the clock dispersion from the time quality
 	 * character.


### PR DESCRIPTION
This patch handles the GPS week rollover that happened in 2019 for old firmware
in Arbiter GPS clocks.

Tested on an Arbiter 1092B.

Signed-off-by: Thomas Tornblom <thomas@hax.se>