### PR TITLE
configure.ac: Add missing comma to atomic_thread_fence check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,7 +400,7 @@ case "$ac_cv_header_stdatomic_h" in
 		    [[
 			atomic_thread_fence(memory_order_seq_cst);
 		    ]]
-		)]
+		)],
 		[ntp_cv_func_atomic_thread_fence=yes],
 		[ntp_cv_func_atomic_thread_fence=no]
 	    )]
@@ -476,7 +476,7 @@ case "$have_adjtimex" in
 			struct nlist n;
 			n.n_un.n_name = 0;
 		    ]]
-		)]
+		)],
 		[ntp_cv_struct_nlist_n_un=yes],
 		[ntp_cv_struct_nlist_n_un=no]
 	    )]
@@ -1104,7 +1104,7 @@ AC_CACHE_CHECK(
 	    [[
 		extern int syscall (int, ...);
 	    ]]
-	)]
+	)],
 	[ntp_cv_decl_syscall=yes],
 	[ntp_cv_decl_syscall=no]
     )]

--- a/sntp/m4/ntp_ipv6.m4
+++ b/sntp/m4/ntp_ipv6.m4
@@ -116,7 +116,7 @@ AC_CACHE_CHECK(
 			# include <sys/socket.h>
 			#endif
 		    ]], [[
-			extern
+			extern int
 			getsockname(int, $getsockname_arg2, 
 				$ntp_cv_getsockname_socklen_type *);
 		    ]]


### PR DESCRIPTION
Without the comma, ntp_cv_func_atomic_thread_fence=yes becomes part of the C source under test, causing compilation and the check to fail.

Found as part of:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
