### PR TITLE
ntpq should report which host lookup failed

### DIFF
--- a/ntpq/ntpq.c
+++ b/ntpq/ntpq.c
@@ -743,7 +743,7 @@ openhost(
 	}
 #endif
 	if (a_info != 0) {
-		fprintf(stderr, "%s\n", gai_strerror(a_info));
+		fprintf(stderr, "%s (%s)\n", gai_strerror(a_info), hname);
 		return 0;
 	}
 


### PR DESCRIPTION
`ntpq` reports `Name does not resolve` given an invalid hostname, but does not report *which* hostname does not resolve.
