### PR TITLE
Fix IPv6 only pools

### DIFF
--- a/ntpd/ntp_proto.c
+++ b/ntpd/ntp_proto.c
@@ -474,7 +474,7 @@ transmit(
 	/* [Bug 3851] drop pool servers which can no longer be reached. */
 	if (MDF_PCLNT & peer->cast_flags) {
 		if (   (IS_IPV6(&peer->srcadr) && !nonlocal_v6_addr_up)
-		    || !nonlocal_v4_addr_up) {
+		    || (IS_IPV4(&peer->srcadr) && !nonlocal_v4_addr_up)) {
 			unpeer(peer);
 			return;
 		}


### PR DESCRIPTION
This is my patch for https://bugs.ntp.org/show_bug.cgi?id=4014