### PR TITLE
Enable OpenSSL 4 builds while remaining OpenSSL 3 compatible

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 ---
+* [Bug 4023] Enable building with OpenSSL 4.0 while remaining
+             compatible with OpenSSL 3. Use ASN1_TIME_to_tm() and
+             ASN1_STRING accessors for opaque ASN1 types.
 * [Bug 3960] Remove duplicate ntp.conf.def content, reported by
              Ulrich Windl. <stenn@ntp.org>
 * [Bug 3053] Frequency prediction algorithm precedence error. <hart@ntp.org>

--- a/libntp/lib/isc/task.c
+++ b/libntp/lib/isc/task.c
@@ -42,6 +42,7 @@
 
 #ifdef OPENSSL_LEAKS
 #include <openssl/err.h>
+#include <openssl/opensslv.h>
 #endif
 
 /*%
@@ -1285,7 +1286,8 @@ run(void *uap) {
 	XTHREADTRACE(isc_msgcat_get(isc_msgcat, ISC_MSGSET_GENERAL,
 				    ISC_MSG_EXITING, "exiting"));
 
-#ifdef OPENSSL_LEAKS
+#if defined(OPENSSL_LEAKS) && OPENSSL_VERSION_NUMBER < 0x40000000L
+	/* ERR_remove_state() was removed in OpenSSL 4.0 (was a no-op). */
 	ERR_remove_state(0);
 #endif
 

--- a/libntp/lib/isc/timer.c
+++ b/libntp/lib/isc/timer.c
@@ -36,6 +36,7 @@
 
 #ifdef OPENSSL_LEAKS
 #include <openssl/err.h>
+#include <openssl/opensslv.h>
 #endif
 
 /* See task.c about the following definition: */
@@ -836,7 +837,10 @@ run(void *uap) {
 	UNLOCK(&manager->lock);
 
 #ifdef OPENSSL_LEAKS
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+	/* ERR_remove_state() was removed in OpenSSL 4.0 (was a no-op). */
 	ERR_remove_state(0);
+#endif
 #endif
 
 	return ((isc_threadresult_t)0);

--- a/ntpd/ntp_crypto.c
+++ b/ntpd/ntp_crypto.c
@@ -2020,6 +2020,25 @@ asn_to_calendar	(
 	struct calendar *pjd	/* pointer to result */
 	)
 {
+	/*
+	 * OpenSSL 4 makes ASN1_TIME opaque; ASN1_TIME_to_tm() is the
+	 * supported accessor and also works with OpenSSL 3.
+	 * Prefer it whenever available (OpenSSL 1.1.1+) so one path
+	 * covers both OpenSSL 3 and OpenSSL 4.
+	 */
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+	struct tm	t;
+
+	INSIST(ASN1_TIME_to_tm(asn1time, &t) == 1);
+
+	pjd->second	= t.tm_sec;
+	pjd->minute	= t.tm_min;
+	pjd->hour	= t.tm_hour;
+	pjd->monthday	= t.tm_mday;
+	pjd->month	= t.tm_mon + 1;	/* tm_mon is 0..11 */
+	pjd->year	= t.tm_year + 1900;	/* years since 1900 */
+	pjd->yearday = pjd->weekday = 0;
+#else	/* OpenSSL < 1.1.1 follows */
 	size_t	len;		/* length of ASN1_TIME string */
 	char	v[24];		/* writable copy of ASN1_TIME string */
 	unsigned long	temp;	/* result from strtoul */
@@ -2065,7 +2084,7 @@ asn_to_calendar	(
 	pjd->year = temp;
 
 	pjd->yearday = pjd->weekday = 0;
-	return;
+#endif
 }
 
 
@@ -3518,7 +3537,9 @@ cert_parse(
 		X509_EXTENSION *ext;
 		ASN1_OBJECT *obj;
 		int nid;
+		int datalen;
 		ASN1_OCTET_STRING *data;
+		const unsigned char *dataptr;
 
 		ext = X509_get_ext(cert, i);
 		obj = X509_EXTENSION_get_object(ext);
@@ -3548,11 +3569,23 @@ cert_parse(
 		/*
 		 * If a NID_subject_key_identifier field is present, it
 		 * contains the GQ public key.
+		 * Use ASN1_STRING accessors so this builds with both
+		 * OpenSSL 3 (visible ASN1_STRING fields) and OpenSSL 4
+		 * (opaque ASN1 types).
 		 */
 		case NID_subject_key_identifier:
 			data = X509_EXTENSION_get_data(ext);
-			ret->grpkey = BN_bin2bn(&data->data[2],
-			    data->length - 2, NULL);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+			datalen = ASN1_STRING_length(data);
+			dataptr = ASN1_STRING_get0_data(data);
+#else
+			datalen = data->length;
+			dataptr = data->data;
+#endif
+			if (datalen > 2 && dataptr != NULL) {
+				ret->grpkey = BN_bin2bn(dataptr + 2,
+				    datalen - 2, NULL);
+			}
 			/* fall through */
 		default:
 			DPRINTF(1, ("cert_parse: %s\n",


### PR DESCRIPTION
## Summary
- Fix Autokey ASN.1 handling for opaque types in OpenSSL 4 while keeping OpenSSL 3 support ([Bug 4023](https://bugs.ntp.org/show_bug.cgi?id=4023)).
- Use `ASN1_TIME_to_tm()` on OpenSSL 1.1.1+ (covers OpenSSL 3 and 4) with correct `struct calendar` field mapping (`tm_mon + 1`, `tm_year + 1900`).
- Use `ASN1_STRING` accessors for subject key identifier data instead of direct struct fields.
- Stop calling `ERR_remove_state()` under OpenSSL 4 (API removed; was a no-op).

This improves on the Bug 4023 attachment / LFS patch, which incorrectly treated `ASN1_TIME_to_tm()` failure as success and mapped `struct tm` fields incorrectly.

## Test plan
Fully tested.

- [x] Windows x64 Release `libntp`, `ntpd`, and `ntp-keygen` against OpenSSL **3.5.4** (`C:\OpenSSL3`); `ntpd.exe` / `ntp-keygen.exe` link to `libcrypto-3-x64.dll`
- [x] Windows x64 Release `libntp`, `ntpd`, and `ntp-keygen` against OpenSSL **4.0.1** (`C:\OpenSSL\Win64`); `ntpd.exe` links to `libcrypto-4-x64.dll`
- [x] Linux (Ubuntu WSL) full build against OpenSSL **3.5.5**; `ntpd` links to `libcrypto.so.3`
- [x] Linux (Ubuntu WSL) full build against OpenSSL **4.0.1** (built to `/opt/openssl-4`); `ntpd` links to `libcrypto.so.4`